### PR TITLE
feat(#2): Episode + Guest data model, gRPC schema, Flyway migration

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -17,9 +17,9 @@ dependencies {
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
     implementation("io.quarkus:quarkus-kotlin")
     implementation("io.quarkus:quarkus-grpc")
-    // PostgreSQL + Hibernate: Issue #2 で追加
-    // implementation("io.quarkus:quarkus-jdbc-postgresql")
-    // implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin")
+    implementation("io.quarkus:quarkus-jdbc-postgresql")
+    implementation("io.quarkus:quarkus-hibernate-orm-panache-kotlin")
+    implementation("io.quarkus:quarkus-flyway")
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-rest")
     implementation("io.quarkus:quarkus-rest-jackson")
@@ -27,6 +27,8 @@ dependencies {
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.rest-assured:rest-assured")
+    testImplementation("io.quarkus:quarkus-jdbc-h2")
+    testImplementation("io.quarkus:quarkus-test-h2")
 }
 
 group = "com.akaitigo"

--- a/backend/src/main/kotlin/com/akaitigo/podflow/model/Episode.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/model/Episode.kt
@@ -1,0 +1,56 @@
+package com.akaitigo.podflow.model
+
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/** A podcast episode with workflow status tracking. */
+@Entity
+@Table(name = "episodes")
+class Episode : PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    var id: UUID? = null
+
+    @Column(name = "title", nullable = false)
+    var title: String = ""
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    var description: String? = null
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: EpisodeStatus = EpisodeStatus.PLANNING
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guest_id")
+    var guest: Guest? = null
+
+    @Column(name = "audio_url")
+    var audioUrl: String? = null
+
+    @Column(name = "show_notes", columnDefinition = "TEXT")
+    var showNotes: String? = null
+
+    @Column(name = "published_at")
+    var publishedAt: Instant? = null
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+}

--- a/backend/src/main/kotlin/com/akaitigo/podflow/model/EpisodeStatus.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/model/EpisodeStatus.kt
@@ -1,0 +1,11 @@
+package com.akaitigo.podflow.model
+
+/** Workflow stages of a podcast episode, matching the kanban columns. */
+enum class EpisodeStatus {
+    PLANNING,
+    GUEST_COORDINATION,
+    RECORDING,
+    EDITING,
+    REVIEW,
+    PUBLISHED,
+}

--- a/backend/src/main/kotlin/com/akaitigo/podflow/model/Guest.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/model/Guest.kt
@@ -1,0 +1,41 @@
+package com.akaitigo.podflow.model
+
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/** A podcast guest. */
+@Entity
+@Table(name = "guests")
+class Guest : PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    var id: UUID? = null
+
+    @Column(name = "name", nullable = false)
+    var name: String = ""
+
+    @Column(name = "email")
+    var email: String? = null
+
+    @Column(name = "bio", columnDefinition = "TEXT")
+    var bio: String? = null
+
+    /** Social media profile URLs stored as JSON array. */
+    @Column(name = "social_links", columnDefinition = "TEXT")
+    var socialLinks: String? = null
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+}

--- a/backend/src/main/kotlin/com/akaitigo/podflow/repository/EpisodeRepository.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/repository/EpisodeRepository.kt
@@ -1,0 +1,10 @@
+package com.akaitigo.podflow.repository
+
+import com.akaitigo.podflow.model.Episode
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/** Repository for [Episode] persistence operations. */
+@ApplicationScoped
+class EpisodeRepository : PanacheRepositoryBase<Episode, UUID>

--- a/backend/src/main/kotlin/com/akaitigo/podflow/repository/GuestRepository.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/repository/GuestRepository.kt
@@ -1,0 +1,10 @@
+package com.akaitigo.podflow.repository
+
+import com.akaitigo.podflow.model.Guest
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/** Repository for [Guest] persistence operations. */
+@ApplicationScoped
+class GuestRepository : PanacheRepositoryBase<Guest, UUID>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,3 +3,15 @@ quarkus.http.port=8080
 
 # gRPC
 quarkus.grpc.server.port=9000
+
+# Database
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/podflow
+quarkus.datasource.username=podflow
+quarkus.datasource.password=podflow
+
+# Hibernate
+quarkus.hibernate-orm.database.generation=validate
+
+# Flyway
+quarkus.flyway.migrate-at-start=true

--- a/backend/src/main/resources/db/migration/V1__create_episodes_and_guests.sql
+++ b/backend/src/main/resources/db/migration/V1__create_episodes_and_guests.sql
@@ -1,0 +1,25 @@
+CREATE TABLE guests (
+    id         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       VARCHAR(255) NOT NULL,
+    email      VARCHAR(255),
+    bio        TEXT,
+    social_links TEXT,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE TABLE episodes (
+    id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    title        VARCHAR(255) NOT NULL,
+    description  TEXT,
+    status       VARCHAR(50)  NOT NULL DEFAULT 'PLANNING',
+    guest_id     UUID         REFERENCES guests(id) ON DELETE SET NULL,
+    audio_url    VARCHAR(2048),
+    show_notes   TEXT,
+    published_at TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_episodes_status ON episodes(status);
+CREATE INDEX idx_episodes_guest_id ON episodes(guest_id);

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.devservices.enabled=false
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:podflow;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.flyway.migrate-at-start=false

--- a/docs/adr/002-data-model.md
+++ b/docs/adr/002-data-model.md
@@ -1,0 +1,54 @@
+# ADR-002: データモデル設計（Episode + Guest）
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+Podflow は Podcast 制作ワークフローを管理するツールである。コアとなるデータモデル（Episode, Guest）の設計が必要。以下の判断を行う必要がある:
+
+1. エンティティの構造と関連
+2. 状態管理（EpisodeStatus）の設計
+3. スキーマ管理方式（Flyway vs Hibernate auto-generation）
+4. Guest の social_links の保存形式
+
+## 決定
+
+### エンティティ構造
+
+- **Episode**: id (UUID), title, description, status, guest_id (FK), audio_url, show_notes, published_at, created_at, updated_at
+- **Guest**: id (UUID), name, email, bio, social_links, created_at, updated_at
+- 関連: Episode N:1 Guest（1エピソードに1ゲスト。将来の複数ゲスト対応は中間テーブルで拡張可能）
+
+### EpisodeStatus（カンバンステージ）
+
+`PLANNING -> GUEST_COORDINATION -> RECORDING -> EDITING -> REVIEW -> PUBLISHED`
+
+- Kotlin 側は `enum class`、DB では `VARCHAR(50)` + `@Enumerated(EnumType.STRING)` で保存
+- 整数値ではなく文字列で保存することで、DB の直接参照時の可読性と安全性を確保
+
+### スキーマ管理: Flyway
+
+- Hibernate `ddl-auto` ではなく Flyway を採用
+- 理由: スキーマ変更の追跡可能性、本番環境での安全性、チーム開発での整合性
+- 開発時: Flyway でマイグレーション実行、Hibernate は `validate` モード
+- テスト時: H2 インメモリ + Hibernate `drop-and-create`（Flyway 無効化）
+
+### social_links: TEXT カラム（JSON 文字列）
+
+- PostgreSQL JSONB ではなく TEXT カラムに JSON 文字列を保存
+- 理由: social_links はクエリ対象にならない表示用データであり、JSONB の利点（インデックス、パーシャルクエリ）が不要
+- H2 テストとの互換性も確保
+
+### Panache Repository パターン
+
+- エンティティとリポジトリを分離する Repository パターンを採用
+- 理由: テスタビリティの向上、関心の分離
+
+## 結果
+
+- Proto 定義が gRPC API の契約として機能する
+- Kotlin エンティティは JPA 標準に準拠し、Panache Repository で CRUD 操作を提供
+- Flyway マイグレーションでスキーマのバージョン管理が可能
+- CI では H2 インメモリ DB によりテストが DB 非依存で実行可能

--- a/plan-issue2.md
+++ b/plan-issue2.md
@@ -1,0 +1,52 @@
+# Plan: Issue #2 データモデル設計
+
+## タスク分解
+
+### Phase 1: Proto 定義
+- [ ] `proto/podflow/v1/episode.proto` — Episode, Guest, EpisodeStatus を定義
+- [ ] `proto/podflow/v1/episode_service.proto` — CRUD RPC を定義
+- [ ] `buf lint proto/` 通過確認
+- [ ] `buf format -w proto/` 実行
+
+### Phase 2: Backend 依存関係
+- [ ] `backend/build.gradle.kts` — PostgreSQL + Hibernate ORM Panache + Flyway 依存を追加
+- [ ] `backend/src/main/resources/application.properties` — DB 設定追加
+
+### Phase 3: Kotlin エンティティ
+- [ ] `Episode.kt` — Episode エンティティ + EpisodeStatus enum
+- [ ] `Guest.kt` — Guest エンティティ
+- [ ] `EpisodeRepository.kt` — Panache Repository
+- [ ] `GuestRepository.kt` — Panache Repository
+
+### Phase 4: Flyway マイグレーション
+- [ ] `V1__create_episodes_and_guests.sql` — テーブル作成 SQL
+
+### Phase 5: テスト設定
+- [ ] テスト用 `application.properties` — DevServices 無効化 + H2 インメモリ
+- [ ] `build.gradle.kts` — H2 テスト依存追加
+- [ ] ビルド確認 (`./gradlew build -x test` or `./gradlew build`)
+
+### Phase 6: ADR
+- [ ] `docs/adr/002-data-model.md` — データモデル設計の判断記録
+
+### Phase 7: 検証 & PR
+- [ ] `make proto-lint` 通過
+- [ ] `./gradlew build` 通過（テスト含む）
+- [ ] PR 作成 → CI 確認 → マージ
+
+## ファイル一覧（新規/変更）
+
+| ファイル | 操作 |
+|---|---|
+| `proto/podflow/v1/episode.proto` | 変更 |
+| `proto/podflow/v1/episode_service.proto` | 新規 |
+| `backend/build.gradle.kts` | 変更 |
+| `backend/src/main/resources/application.properties` | 変更 |
+| `backend/src/test/resources/application.properties` | 新規 |
+| `backend/src/main/kotlin/com/akaitigo/podflow/model/Episode.kt` | 新規 |
+| `backend/src/main/kotlin/com/akaitigo/podflow/model/EpisodeStatus.kt` | 新規 |
+| `backend/src/main/kotlin/com/akaitigo/podflow/model/Guest.kt` | 新規 |
+| `backend/src/main/kotlin/com/akaitigo/podflow/repository/EpisodeRepository.kt` | 新規 |
+| `backend/src/main/kotlin/com/akaitigo/podflow/repository/GuestRepository.kt` | 新規 |
+| `backend/src/main/resources/db/migration/V1__create_episodes_and_guests.sql` | 新規 |
+| `docs/adr/002-data-model.md` | 新規 |

--- a/proto/podflow/v1/episode.proto
+++ b/proto/podflow/v1/episode.proto
@@ -2,5 +2,63 @@ syntax = "proto3";
 
 package podflow.v1;
 
+import "google/protobuf/timestamp.proto";
+
 option java_multiple_files = true;
 option java_package = "com.akaitigo.podflow.grpc";
+
+// EpisodeStatus represents the workflow stage of a podcast episode.
+enum EpisodeStatus {
+  // Default unspecified value.
+  EPISODE_STATUS_UNSPECIFIED = 0;
+  // Episode is in initial planning phase.
+  EPISODE_STATUS_PLANNING = 1;
+  // Coordinating with guest(s) for scheduling.
+  EPISODE_STATUS_GUEST_COORDINATION = 2;
+  // Episode is being recorded.
+  EPISODE_STATUS_RECORDING = 3;
+  // Post-production editing in progress.
+  EPISODE_STATUS_EDITING = 4;
+  // Episode is under review before publishing.
+  EPISODE_STATUS_REVIEW = 5;
+  // Episode has been published.
+  EPISODE_STATUS_PUBLISHED = 6;
+}
+
+// Guest represents a podcast guest.
+message Guest {
+  // Unique identifier for the guest.
+  string id = 1;
+  // Full name of the guest.
+  string name = 2;
+  // Email address of the guest.
+  string email = 3;
+  // Short biography of the guest.
+  string bio = 4;
+  // List of social media profile URLs.
+  repeated string social_links = 5;
+}
+
+// Episode represents a single podcast episode and its metadata.
+message Episode {
+  // Unique identifier for the episode.
+  string id = 1;
+  // Title of the episode.
+  string title = 2;
+  // Description or summary of the episode.
+  string description = 3;
+  // Current workflow status of the episode.
+  EpisodeStatus status = 4;
+  // Identifier of the associated guest.
+  string guest_id = 5;
+  // URL to the audio file.
+  string audio_url = 6;
+  // Show notes in markdown format.
+  string show_notes = 7;
+  // Timestamp when the episode was published.
+  google.protobuf.Timestamp published_at = 8;
+  // Timestamp when the episode was created.
+  google.protobuf.Timestamp created_at = 9;
+  // Timestamp when the episode was last updated.
+  google.protobuf.Timestamp updated_at = 10;
+}

--- a/proto/podflow/v1/episode_service.proto
+++ b/proto/podflow/v1/episode_service.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package podflow.v1;
+
+import "podflow/v1/episode.proto";
+
+option java_multiple_files = true;
+option java_package = "com.akaitigo.podflow.grpc";
+
+// CreateEpisodeRequest is the request message for creating an episode.
+message CreateEpisodeRequest {
+  // Title of the episode to create.
+  string title = 1;
+  // Description or summary of the episode.
+  string description = 2;
+  // Identifier of the associated guest.
+  string guest_id = 3;
+}
+
+// CreateEpisodeResponse is the response message for creating an episode.
+message CreateEpisodeResponse {
+  // The created episode.
+  Episode episode = 1;
+}
+
+// GetEpisodeRequest is the request message for retrieving an episode.
+message GetEpisodeRequest {
+  // Unique identifier of the episode to retrieve.
+  string id = 1;
+}
+
+// GetEpisodeResponse is the response message for retrieving an episode.
+message GetEpisodeResponse {
+  // The requested episode.
+  Episode episode = 1;
+}
+
+// ListEpisodesRequest is the request message for listing episodes.
+message ListEpisodesRequest {
+  // Maximum number of episodes to return.
+  int32 page_size = 1;
+  // Token for pagination.
+  string page_token = 2;
+  // Optional status filter.
+  EpisodeStatus status_filter = 3;
+}
+
+// ListEpisodesResponse is the response message for listing episodes.
+message ListEpisodesResponse {
+  // The list of episodes.
+  repeated Episode episodes = 1;
+  // Token for the next page, empty if no more results.
+  string next_page_token = 2;
+}
+
+// UpdateEpisodeRequest is the request message for updating an episode.
+message UpdateEpisodeRequest {
+  // The episode with updated fields.
+  Episode episode = 1;
+}
+
+// UpdateEpisodeResponse is the response message for updating an episode.
+message UpdateEpisodeResponse {
+  // The updated episode.
+  Episode episode = 1;
+}
+
+// DeleteEpisodeRequest is the request message for deleting an episode.
+message DeleteEpisodeRequest {
+  // Unique identifier of the episode to delete.
+  string id = 1;
+}
+
+// DeleteEpisodeResponse is the response message for deleting an episode.
+message DeleteEpisodeResponse {}
+
+// EpisodeService provides CRUD operations for podcast episodes.
+service EpisodeService {
+  // CreateEpisode creates a new episode.
+  rpc CreateEpisode(CreateEpisodeRequest) returns (CreateEpisodeResponse);
+  // GetEpisode retrieves an episode by its identifier.
+  rpc GetEpisode(GetEpisodeRequest) returns (GetEpisodeResponse);
+  // ListEpisodes returns a paginated list of episodes.
+  rpc ListEpisodes(ListEpisodesRequest) returns (ListEpisodesResponse);
+  // UpdateEpisode updates an existing episode.
+  rpc UpdateEpisode(UpdateEpisodeRequest) returns (UpdateEpisodeResponse);
+  // DeleteEpisode removes an episode.
+  rpc DeleteEpisode(DeleteEpisodeRequest) returns (DeleteEpisodeResponse);
+}

--- a/research-issue2.md
+++ b/research-issue2.md
@@ -1,0 +1,90 @@
+# Research: Issue #2 データモデル設計
+
+## 1. EpisodeStatus の状態遷移
+
+```
+PLANNING → GUEST_COORDINATION → RECORDING → EDITING → REVIEW → PUBLISHED
+```
+
+- 基本は線形フロー（カンバンの左→右）
+- 状態の巻き戻し（例: REVIEW → EDITING）は許容する（修正フロー）
+- UNSPECIFIED (= 0) を proto3 のデフォルト値として含める（buf lint ENUM_ZERO_VALUE_SUFFIX 準拠）
+
+## 2. Proto message/service 設計
+
+### episode.proto
+- `Episode` message: id (string/UUID), title, description, status, guest_id, audio_url, show_notes, published_at, created_at, updated_at
+- `Guest` message: id, name, email, bio, social_links (repeated string)
+- `EpisodeStatus` enum: EPISODE_STATUS_UNSPECIFIED = 0, PLANNING = 1, GUEST_COORDINATION = 2, RECORDING = 3, EDITING = 4, REVIEW = 5, PUBLISHED = 6
+
+### episode_service.proto
+- `EpisodeService`: CreateEpisode, GetEpisode, ListEpisodes, UpdateEpisode, DeleteEpisode
+- Request/Response パターン: 各 RPC に専用の Request/Response message を定義
+- ListEpisodes にはページネーション（page_size, page_token）を含める
+
+### buf lint 準拠ポイント
+- COMMENTS ルール: 全 message, enum, field, rpc にコメント必須
+- ENUM_ZERO_VALUE_SUFFIX: enum の 0 値は `_UNSPECIFIED` サフィックス
+- RPC Request/Response suffix: `XxxRequest` / `XxxResponse`
+
+## 3. Kotlin エンティティ設計
+
+### パターン選定: Panache Repository パターン
+- Quarkus Hibernate ORM Panache Kotlin を使用
+- Repository パターン（Entity と Repository を分離）を採用
+  - テスタビリティが高い
+  - エンティティがフレームワーク非依存に近い
+
+### Episode エンティティ
+```kotlin
+@Entity
+@Table(name = "episodes")
+class Episode {
+    @Id @GeneratedValue lateinit var id: UUID
+    lateinit var title: String
+    var description: String? = null
+    @Enumerated(EnumType.STRING) var status: EpisodeStatus = EpisodeStatus.PLANNING
+    @ManyToOne var guest: Guest? = null
+    var audioUrl: String? = null
+    @Column(columnDefinition = "TEXT") var showNotes: String? = null
+    var publishedAt: Instant? = null
+    lateinit var createdAt: Instant
+    lateinit var updatedAt: Instant
+}
+```
+
+### Guest エンティティ
+```kotlin
+@Entity
+@Table(name = "guests")
+class Guest {
+    @Id @GeneratedValue lateinit var id: UUID
+    lateinit var name: String
+    var email: String? = null
+    var bio: String? = null
+    // social_links は JSON カラムまたは別テーブル
+}
+```
+
+### social_links の保存方式
+- 選択肢: (A) JSON カラム, (B) 正規化テーブル
+- 決定: (A) JSON カラム — social_links は表示用途のみでクエリ対象にならないため
+- PostgreSQL の JSONB 型 + JPA Converter を使用
+
+## 4. Flyway vs Hibernate auto-generation
+
+### 決定: Flyway
+- 理由:
+  1. スキーマ変更の履歴が明確（マイグレーションファイルで追跡可能）
+  2. 本番環境で安全（Hibernate ddl-auto は本番では none/validate のみ推奨）
+  3. チーム開発でのスキーマ管理が容易
+- 開発時: Flyway でマイグレーション実行 + Hibernate validate
+- CI: DB なしビルドではマイグレーション SQL の存在確認のみ
+
+## 5. CI 考慮事項
+
+### DB テスト問題
+- CI 環境（GitHub Actions）では PostgreSQL サービスコンテナを使える
+- 現時点では DB テストは不要（エンティティのコンパイル確認のみ）
+- `@QuarkusTest` は DevServices で PostgreSQL を自動起動するが、CI で失敗する可能性あり
+- 対策: テストプロファイル (`application.properties`) で DevServices を無効化し、H2 インメモリを使用


### PR DESCRIPTION
## Summary

Closes #2

- **Proto**: `Episode`, `Guest` messages + `EpisodeStatus` enum in `episode.proto`; `EpisodeService` with 5 CRUD RPCs in `episode_service.proto`
- **Backend**: Kotlin/Hibernate ORM entities (`Episode`, `Guest`, `EpisodeStatus`) with Panache Repository pattern; PostgreSQL + Flyway + H2 test profile dependencies
- **Migration**: Flyway `V1__create_episodes_and_guests.sql` creating `guests` and `episodes` tables with indexes
- **ADR**: `docs/adr/002-data-model.md` documenting entity structure, status enum design, Flyway choice, and social_links storage decision

## Design decisions (ADR-002)

- **EpisodeStatus**: String-based enum (`@Enumerated(EnumType.STRING)`) for DB readability
- **Schema management**: Flyway (not Hibernate ddl-auto) for production safety and change traceability
- **social_links**: TEXT column with JSON string (not JSONB) for H2 test compatibility and simplicity
- **Repository pattern**: Panache Repository for testability and separation of concerns

## Verification

- `buf lint proto/` -- passed
- `buf format --diff proto/` -- no diff
- `./gradlew build` (with tests) -- passed
- `make proto-lint` -- passed

## Test plan

- [x] `buf lint` passes with STANDARD + COMMENTS rules
- [x] `buf format --diff` shows no differences
- [x] Backend compiles with all new entities and dependencies
- [x] Existing `HealthResourceTest` still passes with H2 test profile
- [ ] CI proto-lint job passes
- [ ] CI frontend job passes (no changes)
- [ ] CI backend job passes