### PR TITLE
feat(#3): Episode CRUD gRPC service with status transition

### DIFF
--- a/backend/src/main/kotlin/com/akaitigo/podflow/model/EpisodeStatus.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/model/EpisodeStatus.kt
@@ -8,4 +8,19 @@ enum class EpisodeStatus {
     EDITING,
     REVIEW,
     PUBLISHED,
+    ;
+
+    /** Returns the set of statuses this status is allowed to transition to. */
+    fun allowedTransitions(): Set<EpisodeStatus> =
+        when (this) {
+            PLANNING -> setOf(GUEST_COORDINATION, RECORDING)
+            GUEST_COORDINATION -> setOf(RECORDING)
+            RECORDING -> setOf(EDITING)
+            EDITING -> setOf(REVIEW)
+            REVIEW -> setOf(EDITING, PUBLISHED)
+            PUBLISHED -> emptySet()
+        }
+
+    /** Returns true if transitioning from this status to [target] is valid. */
+    fun canTransitionTo(target: EpisodeStatus): Boolean = target in allowedTransitions()
 }

--- a/backend/src/main/kotlin/com/akaitigo/podflow/service/EpisodeGrpcService.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/service/EpisodeGrpcService.kt
@@ -1,0 +1,248 @@
+package com.akaitigo.podflow.service
+
+import com.akaitigo.podflow.grpc.CreateEpisodeRequest
+import com.akaitigo.podflow.grpc.CreateEpisodeResponse
+import com.akaitigo.podflow.grpc.DeleteEpisodeRequest
+import com.akaitigo.podflow.grpc.DeleteEpisodeResponse
+import com.akaitigo.podflow.grpc.EpisodeService
+import com.akaitigo.podflow.grpc.GetEpisodeRequest
+import com.akaitigo.podflow.grpc.GetEpisodeResponse
+import com.akaitigo.podflow.grpc.ListEpisodesRequest
+import com.akaitigo.podflow.grpc.ListEpisodesResponse
+import com.akaitigo.podflow.grpc.UpdateEpisodeRequest
+import com.akaitigo.podflow.grpc.UpdateEpisodeResponse
+import com.akaitigo.podflow.model.Episode
+import com.akaitigo.podflow.model.EpisodeStatus
+import com.akaitigo.podflow.repository.EpisodeRepository
+import com.akaitigo.podflow.repository.GuestRepository
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.quarkus.grpc.GrpcService
+import io.smallrye.common.annotation.Blocking
+import io.smallrye.mutiny.Uni
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import java.time.Instant
+import java.util.UUID
+import com.akaitigo.podflow.grpc.EpisodeStatus as ProtoEpisodeStatus
+
+/** gRPC service implementing Episode CRUD operations. */
+@GrpcService
+@Blocking
+@Transactional
+class EpisodeGrpcService : EpisodeService {
+
+    @Inject
+    lateinit var episodeRepository: EpisodeRepository
+
+    @Inject
+    lateinit var guestRepository: GuestRepository
+
+    @Inject
+    lateinit var episodeMapper: EpisodeMapper
+
+    override fun createEpisode(request: CreateEpisodeRequest): Uni<CreateEpisodeResponse> =
+        Uni.createFrom().item {
+            validateTitle(request.title)
+
+            val episode = Episode().apply {
+                title = request.title
+                description = request.description.ifEmpty { null }
+                status = EpisodeStatus.PLANNING
+                createdAt = Instant.now()
+                updatedAt = Instant.now()
+            }
+
+            if (request.guestId.isNotEmpty()) {
+                val guestId = parseUuid(request.guestId, "guest_id")
+                val guest = guestRepository.findById(guestId)
+                    ?: throw StatusRuntimeException(
+                        Status.NOT_FOUND.withDescription("Guest not found: ${request.guestId}"),
+                    )
+                episode.guest = guest
+            }
+
+            episodeRepository.persistAndFlush(episode)
+
+            CreateEpisodeResponse.newBuilder()
+                .setEpisode(episodeMapper.toProto(episode))
+                .build()
+        }
+
+    override fun getEpisode(request: GetEpisodeRequest): Uni<GetEpisodeResponse> =
+        Uni.createFrom().item {
+            val id = parseUuid(request.id, "id")
+            val episode = findEpisodeOrThrow(id)
+
+            GetEpisodeResponse.newBuilder()
+                .setEpisode(episodeMapper.toProto(episode))
+                .build()
+        }
+
+    override fun listEpisodes(request: ListEpisodesRequest): Uni<ListEpisodesResponse> =
+        Uni.createFrom().item {
+            val pageSize = if (request.pageSize > 0) { request.pageSize } else { DEFAULT_PAGE_SIZE }
+            val offset = parsePageToken(request.pageToken)
+
+            val hasStatusFilter =
+                request.statusFilter != ProtoEpisodeStatus.EPISODE_STATUS_UNSPECIFIED &&
+                    request.statusFilter != ProtoEpisodeStatus.UNRECOGNIZED
+
+            val query = if (hasStatusFilter) {
+                val modelStatus = episodeMapper.toModelStatus(request.statusFilter)
+                episodeRepository.find("status", modelStatus)
+            } else {
+                episodeRepository.findAll()
+            }
+
+            val episodes = query.page(offset, pageSize).list()
+
+            val builder = ListEpisodesResponse.newBuilder()
+            episodes.forEach { builder.addEpisodes(episodeMapper.toProto(it)) }
+
+            if (episodes.size == pageSize) {
+                builder.nextPageToken = (offset + 1).toString()
+            }
+
+            builder.build()
+        }
+
+    override fun updateEpisode(request: UpdateEpisodeRequest): Uni<UpdateEpisodeResponse> =
+        Uni.createFrom().item {
+            val protoEpisode = request.episode
+                ?: throw StatusRuntimeException(
+                    Status.INVALID_ARGUMENT.withDescription("Episode field is required"),
+                )
+
+            val id = parseUuid(protoEpisode.id, "id")
+            val existing = findEpisodeOrThrow(id)
+
+            applyFieldUpdates(existing, protoEpisode)
+            applyStatusUpdate(existing, protoEpisode)
+            applyGuestUpdate(existing, protoEpisode)
+
+            existing.updatedAt = Instant.now()
+            episodeRepository.persistAndFlush(existing)
+
+            UpdateEpisodeResponse.newBuilder()
+                .setEpisode(episodeMapper.toProto(existing))
+                .build()
+        }
+
+    override fun deleteEpisode(request: DeleteEpisodeRequest): Uni<DeleteEpisodeResponse> =
+        Uni.createFrom().item {
+            val id = parseUuid(request.id, "id")
+            val episode = findEpisodeOrThrow(id)
+            episodeRepository.delete(episode)
+
+            DeleteEpisodeResponse.getDefaultInstance()
+        }
+
+    private fun applyFieldUpdates(
+        existing: Episode,
+        proto: com.akaitigo.podflow.grpc.Episode,
+    ) {
+        if (proto.title.isNotEmpty()) {
+            validateTitle(proto.title)
+            existing.title = proto.title
+        }
+        if (proto.description.isNotEmpty()) {
+            existing.description = proto.description
+        }
+        if (proto.audioUrl.isNotEmpty()) {
+            existing.audioUrl = proto.audioUrl
+        }
+        if (proto.showNotes.isNotEmpty()) {
+            existing.showNotes = proto.showNotes
+        }
+    }
+
+    private fun applyStatusUpdate(
+        existing: Episode,
+        proto: com.akaitigo.podflow.grpc.Episode,
+    ) {
+        val hasStatusUpdate =
+            proto.status != ProtoEpisodeStatus.EPISODE_STATUS_UNSPECIFIED &&
+                proto.status != ProtoEpisodeStatus.UNRECOGNIZED
+
+        if (hasStatusUpdate) {
+            val newStatus = episodeMapper.toModelStatus(proto.status)
+            validateStatusTransition(existing.status, newStatus)
+            existing.status = newStatus
+
+            if (newStatus == EpisodeStatus.PUBLISHED) {
+                existing.publishedAt = Instant.now()
+            }
+        }
+    }
+
+    private fun applyGuestUpdate(
+        existing: Episode,
+        proto: com.akaitigo.podflow.grpc.Episode,
+    ) {
+        if (proto.guestId.isNotEmpty()) {
+            val guestId = parseUuid(proto.guestId, "guest_id")
+            val guest = guestRepository.findById(guestId)
+                ?: throw StatusRuntimeException(
+                    Status.NOT_FOUND.withDescription("Guest not found: ${proto.guestId}"),
+                )
+            existing.guest = guest
+        }
+    }
+
+    private fun findEpisodeOrThrow(id: UUID): Episode =
+        episodeRepository.findById(id)
+            ?: throw StatusRuntimeException(
+                Status.NOT_FOUND.withDescription("Episode not found: $id"),
+            )
+
+    private fun validateTitle(title: String) {
+        if (title.isBlank()) {
+            throw StatusRuntimeException(
+                Status.INVALID_ARGUMENT.withDescription("Title must not be blank"),
+            )
+        }
+    }
+
+    private fun validateStatusTransition(current: EpisodeStatus, target: EpisodeStatus) {
+        if (!current.canTransitionTo(target)) {
+            throw StatusRuntimeException(
+                Status.INVALID_ARGUMENT.withDescription(
+                    "Invalid status transition from $current to $target",
+                ),
+            )
+        }
+    }
+
+    private fun parseUuid(value: String, fieldName: String): UUID =
+        try {
+            UUID.fromString(value)
+        } catch (_: IllegalArgumentException) {
+            throw StatusRuntimeException(
+                Status.INVALID_ARGUMENT.withDescription("Invalid UUID for $fieldName: $value"),
+            )
+        }
+
+    private fun parsePageToken(token: String): Int {
+        if (token.isEmpty()) {
+            return 0
+        }
+        return try {
+            val page = token.toInt()
+            if (page < 0) {
+                throw StatusRuntimeException(
+                    Status.INVALID_ARGUMENT.withDescription("page_token must be non-negative"),
+                )
+            }
+            page
+        } catch (_: NumberFormatException) {
+            throw StatusRuntimeException(
+                Status.INVALID_ARGUMENT.withDescription("Invalid page_token: $token"),
+            )
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_PAGE_SIZE = 20
+    }
+}

--- a/backend/src/main/kotlin/com/akaitigo/podflow/service/EpisodeMapper.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/service/EpisodeMapper.kt
@@ -1,0 +1,64 @@
+package com.akaitigo.podflow.service
+
+import com.akaitigo.podflow.model.Episode
+import com.akaitigo.podflow.model.EpisodeStatus
+import com.google.protobuf.Timestamp
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import com.akaitigo.podflow.grpc.Episode as ProtoEpisode
+import com.akaitigo.podflow.grpc.EpisodeStatus as ProtoEpisodeStatus
+
+/** Converts between JPA [Episode] entities and proto [ProtoEpisode] messages. */
+@ApplicationScoped
+class EpisodeMapper {
+
+    /** Converts a JPA entity to a proto message. */
+    fun toProto(entity: Episode): ProtoEpisode {
+        val builder = ProtoEpisode.newBuilder()
+            .setTitle(entity.title)
+            .setDescription(entity.description.orEmpty())
+            .setStatus(toProtoStatus(entity.status))
+            .setAudioUrl(entity.audioUrl.orEmpty())
+            .setShowNotes(entity.showNotes.orEmpty())
+
+        entity.id?.let { builder.setId(it.toString()) }
+        entity.guest?.id?.let { builder.setGuestId(it.toString()) }
+        entity.publishedAt?.let { builder.setPublishedAt(toTimestamp(it)) }
+        entity.createdAt.let { builder.setCreatedAt(toTimestamp(it)) }
+        entity.updatedAt.let { builder.setUpdatedAt(toTimestamp(it)) }
+
+        return builder.build()
+    }
+
+    /** Converts a proto [ProtoEpisodeStatus] to a Kotlin [EpisodeStatus]. */
+    fun toModelStatus(proto: ProtoEpisodeStatus): EpisodeStatus =
+        when (proto) {
+            ProtoEpisodeStatus.EPISODE_STATUS_PLANNING -> EpisodeStatus.PLANNING
+            ProtoEpisodeStatus.EPISODE_STATUS_GUEST_COORDINATION -> EpisodeStatus.GUEST_COORDINATION
+            ProtoEpisodeStatus.EPISODE_STATUS_RECORDING -> EpisodeStatus.RECORDING
+            ProtoEpisodeStatus.EPISODE_STATUS_EDITING -> EpisodeStatus.EDITING
+            ProtoEpisodeStatus.EPISODE_STATUS_REVIEW -> EpisodeStatus.REVIEW
+            ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED -> EpisodeStatus.PUBLISHED
+            ProtoEpisodeStatus.EPISODE_STATUS_UNSPECIFIED, ProtoEpisodeStatus.UNRECOGNIZED ->
+                throw io.grpc.StatusRuntimeException(
+                    io.grpc.Status.INVALID_ARGUMENT.withDescription("Invalid episode status: $proto"),
+                )
+        }
+
+    /** Converts a Kotlin [EpisodeStatus] to a proto [ProtoEpisodeStatus]. */
+    fun toProtoStatus(status: EpisodeStatus): ProtoEpisodeStatus =
+        when (status) {
+            EpisodeStatus.PLANNING -> ProtoEpisodeStatus.EPISODE_STATUS_PLANNING
+            EpisodeStatus.GUEST_COORDINATION -> ProtoEpisodeStatus.EPISODE_STATUS_GUEST_COORDINATION
+            EpisodeStatus.RECORDING -> ProtoEpisodeStatus.EPISODE_STATUS_RECORDING
+            EpisodeStatus.EDITING -> ProtoEpisodeStatus.EPISODE_STATUS_EDITING
+            EpisodeStatus.REVIEW -> ProtoEpisodeStatus.EPISODE_STATUS_REVIEW
+            EpisodeStatus.PUBLISHED -> ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED
+        }
+
+    private fun toTimestamp(instant: Instant): Timestamp =
+        Timestamp.newBuilder()
+            .setSeconds(instant.epochSecond)
+            .setNanos(instant.nano)
+            .build()
+}

--- a/backend/src/main/proto/podflow/v1/episode.proto
+++ b/backend/src/main/proto/podflow/v1/episode.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package podflow.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_package = "com.akaitigo.podflow.grpc";
+
+// EpisodeStatus represents the workflow stage of a podcast episode.
+enum EpisodeStatus {
+  // Default unspecified value.
+  EPISODE_STATUS_UNSPECIFIED = 0;
+  // Episode is in initial planning phase.
+  EPISODE_STATUS_PLANNING = 1;
+  // Coordinating with guest(s) for scheduling.
+  EPISODE_STATUS_GUEST_COORDINATION = 2;
+  // Episode is being recorded.
+  EPISODE_STATUS_RECORDING = 3;
+  // Post-production editing in progress.
+  EPISODE_STATUS_EDITING = 4;
+  // Episode is under review before publishing.
+  EPISODE_STATUS_REVIEW = 5;
+  // Episode has been published.
+  EPISODE_STATUS_PUBLISHED = 6;
+}
+
+// Guest represents a podcast guest.
+message Guest {
+  // Unique identifier for the guest.
+  string id = 1;
+  // Full name of the guest.
+  string name = 2;
+  // Email address of the guest.
+  string email = 3;
+  // Short biography of the guest.
+  string bio = 4;
+  // List of social media profile URLs.
+  repeated string social_links = 5;
+}
+
+// Episode represents a single podcast episode and its metadata.
+message Episode {
+  // Unique identifier for the episode.
+  string id = 1;
+  // Title of the episode.
+  string title = 2;
+  // Description or summary of the episode.
+  string description = 3;
+  // Current workflow status of the episode.
+  EpisodeStatus status = 4;
+  // Identifier of the associated guest.
+  string guest_id = 5;
+  // URL to the audio file.
+  string audio_url = 6;
+  // Show notes in markdown format.
+  string show_notes = 7;
+  // Timestamp when the episode was published.
+  google.protobuf.Timestamp published_at = 8;
+  // Timestamp when the episode was created.
+  google.protobuf.Timestamp created_at = 9;
+  // Timestamp when the episode was last updated.
+  google.protobuf.Timestamp updated_at = 10;
+}

--- a/backend/src/main/proto/podflow/v1/episode_service.proto
+++ b/backend/src/main/proto/podflow/v1/episode_service.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package podflow.v1;
+
+import "podflow/v1/episode.proto";
+
+option java_multiple_files = true;
+option java_package = "com.akaitigo.podflow.grpc";
+
+// CreateEpisodeRequest is the request message for creating an episode.
+message CreateEpisodeRequest {
+  // Title of the episode to create.
+  string title = 1;
+  // Description or summary of the episode.
+  string description = 2;
+  // Identifier of the associated guest.
+  string guest_id = 3;
+}
+
+// CreateEpisodeResponse is the response message for creating an episode.
+message CreateEpisodeResponse {
+  // The created episode.
+  Episode episode = 1;
+}
+
+// GetEpisodeRequest is the request message for retrieving an episode.
+message GetEpisodeRequest {
+  // Unique identifier of the episode to retrieve.
+  string id = 1;
+}
+
+// GetEpisodeResponse is the response message for retrieving an episode.
+message GetEpisodeResponse {
+  // The requested episode.
+  Episode episode = 1;
+}
+
+// ListEpisodesRequest is the request message for listing episodes.
+message ListEpisodesRequest {
+  // Maximum number of episodes to return.
+  int32 page_size = 1;
+  // Token for pagination.
+  string page_token = 2;
+  // Optional status filter.
+  EpisodeStatus status_filter = 3;
+}
+
+// ListEpisodesResponse is the response message for listing episodes.
+message ListEpisodesResponse {
+  // The list of episodes.
+  repeated Episode episodes = 1;
+  // Token for the next page, empty if no more results.
+  string next_page_token = 2;
+}
+
+// UpdateEpisodeRequest is the request message for updating an episode.
+message UpdateEpisodeRequest {
+  // The episode with updated fields.
+  Episode episode = 1;
+}
+
+// UpdateEpisodeResponse is the response message for updating an episode.
+message UpdateEpisodeResponse {
+  // The updated episode.
+  Episode episode = 1;
+}
+
+// DeleteEpisodeRequest is the request message for deleting an episode.
+message DeleteEpisodeRequest {
+  // Unique identifier of the episode to delete.
+  string id = 1;
+}
+
+// DeleteEpisodeResponse is the response message for deleting an episode.
+message DeleteEpisodeResponse {}
+
+// EpisodeService provides CRUD operations for podcast episodes.
+service EpisodeService {
+  // CreateEpisode creates a new episode.
+  rpc CreateEpisode(CreateEpisodeRequest) returns (CreateEpisodeResponse);
+  // GetEpisode retrieves an episode by its identifier.
+  rpc GetEpisode(GetEpisodeRequest) returns (GetEpisodeResponse);
+  // ListEpisodes returns a paginated list of episodes.
+  rpc ListEpisodes(ListEpisodesRequest) returns (ListEpisodesResponse);
+  // UpdateEpisode updates an existing episode.
+  rpc UpdateEpisode(UpdateEpisodeRequest) returns (UpdateEpisodeResponse);
+  // DeleteEpisode removes an episode.
+  rpc DeleteEpisode(DeleteEpisodeRequest) returns (DeleteEpisodeResponse);
+}

--- a/backend/src/test/kotlin/com/akaitigo/podflow/model/EpisodeStatusTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/podflow/model/EpisodeStatusTest.kt
@@ -1,0 +1,70 @@
+package com.akaitigo.podflow.model
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class EpisodeStatusTest {
+
+    @ParameterizedTest(name = "{0} -> {1} should be allowed")
+    @CsvSource(
+        "PLANNING, GUEST_COORDINATION",
+        "PLANNING, RECORDING",
+        "GUEST_COORDINATION, RECORDING",
+        "RECORDING, EDITING",
+        "EDITING, REVIEW",
+        "REVIEW, EDITING",
+        "REVIEW, PUBLISHED",
+    )
+    fun `valid transitions are allowed`(from: EpisodeStatus, to: EpisodeStatus) {
+        assertTrue(from.canTransitionTo(to)) {
+            "$from -> $to should be a valid transition"
+        }
+    }
+
+    @ParameterizedTest(name = "{0} -> {1} should be rejected")
+    @CsvSource(
+        "PLANNING, EDITING",
+        "PLANNING, REVIEW",
+        "PLANNING, PUBLISHED",
+        "GUEST_COORDINATION, PLANNING",
+        "GUEST_COORDINATION, EDITING",
+        "RECORDING, PLANNING",
+        "RECORDING, PUBLISHED",
+        "EDITING, PLANNING",
+        "EDITING, RECORDING",
+        "REVIEW, PLANNING",
+        "REVIEW, RECORDING",
+        "PUBLISHED, PLANNING",
+        "PUBLISHED, RECORDING",
+        "PUBLISHED, EDITING",
+    )
+    fun `invalid transitions are rejected`(from: EpisodeStatus, to: EpisodeStatus) {
+        assertFalse(from.canTransitionTo(to)) {
+            "$from -> $to should not be a valid transition"
+        }
+    }
+
+    @Test
+    fun `published has no allowed transitions`() {
+        assertTrue(EpisodeStatus.PUBLISHED.allowedTransitions().isEmpty())
+    }
+
+    @Test
+    fun `planning allows guest coordination and recording`() {
+        val allowed = EpisodeStatus.PLANNING.allowedTransitions()
+        assertTrue(allowed.contains(EpisodeStatus.GUEST_COORDINATION))
+        assertTrue(allowed.contains(EpisodeStatus.RECORDING))
+    }
+
+    @Test
+    fun `self transition is not allowed for any status`() {
+        EpisodeStatus.entries.forEach { status ->
+            assertFalse(status.canTransitionTo(status)) {
+                "$status -> $status (self transition) should not be allowed"
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/akaitigo/podflow/service/EpisodeGrpcServiceTest.kt
+++ b/backend/src/test/kotlin/com/akaitigo/podflow/service/EpisodeGrpcServiceTest.kt
@@ -1,0 +1,388 @@
+package com.akaitigo.podflow.service
+
+import com.akaitigo.podflow.grpc.CreateEpisodeRequest
+import com.akaitigo.podflow.grpc.DeleteEpisodeRequest
+import com.akaitigo.podflow.grpc.EpisodeService
+import com.akaitigo.podflow.grpc.GetEpisodeRequest
+import com.akaitigo.podflow.grpc.ListEpisodesRequest
+import com.akaitigo.podflow.grpc.UpdateEpisodeRequest
+import com.akaitigo.podflow.model.Guest
+import com.akaitigo.podflow.repository.GuestRepository
+import io.grpc.StatusRuntimeException
+import io.quarkus.grpc.GrpcClient
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import com.akaitigo.podflow.grpc.Episode as ProtoEpisode
+import com.akaitigo.podflow.grpc.EpisodeStatus as ProtoEpisodeStatus
+
+@QuarkusTest
+class EpisodeGrpcServiceTest {
+
+    @GrpcClient("episode-service")
+    lateinit var client: EpisodeService
+
+    @Inject
+    lateinit var guestRepository: GuestRepository
+
+    @Inject
+    lateinit var episodeRepository: com.akaitigo.podflow.repository.EpisodeRepository
+
+    @BeforeEach
+    @Transactional
+    fun cleanup() {
+        episodeRepository.deleteAll()
+        guestRepository.deleteAll()
+    }
+
+    @Test
+    fun `createEpisode returns episode with generated id`() {
+        val request = CreateEpisodeRequest.newBuilder()
+            .setTitle("Test Episode")
+            .setDescription("A test episode")
+            .build()
+
+        val response = client.createEpisode(request).await().indefinitely()
+        val episode = response.episode
+
+        assertNotNull(episode)
+        assertTrue(episode.id.isNotEmpty())
+        assertEquals("Test Episode", episode.title)
+        assertEquals("A test episode", episode.description)
+        assertEquals(ProtoEpisodeStatus.EPISODE_STATUS_PLANNING, episode.status)
+    }
+
+    @Test
+    fun `createEpisode with blank title fails`() {
+        val request = CreateEpisodeRequest.newBuilder()
+            .setTitle("  ")
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.createEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.INVALID_ARGUMENT.code, exception.status.code)
+        assertTrue(requireNotNull(exception.status.description).contains("Title"))
+    }
+
+    @Test
+    fun `createEpisode with guest`() {
+        val guest = createTestGuest()
+
+        val request = CreateEpisodeRequest.newBuilder()
+            .setTitle("Guest Episode")
+            .setGuestId(requireNotNull(guest.id).toString())
+            .build()
+
+        val response = client.createEpisode(request).await().indefinitely()
+        assertEquals(requireNotNull(guest.id).toString(), response.episode.guestId)
+    }
+
+    @Test
+    fun `createEpisode with nonexistent guest fails`() {
+        val request = CreateEpisodeRequest.newBuilder()
+            .setTitle("Guest Episode")
+            .setGuestId("00000000-0000-0000-0000-000000000001")
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.createEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.NOT_FOUND.code, exception.status.code)
+    }
+
+    @Test
+    fun `getEpisode returns existing episode`() {
+        val created = createTestEpisode("Get Me")
+
+        val request = GetEpisodeRequest.newBuilder()
+            .setId(created.id)
+            .build()
+
+        val response = client.getEpisode(request).await().indefinitely()
+        assertEquals(created.id, response.episode.id)
+        assertEquals("Get Me", response.episode.title)
+    }
+
+    @Test
+    fun `getEpisode with nonexistent id fails`() {
+        val request = GetEpisodeRequest.newBuilder()
+            .setId("00000000-0000-0000-0000-000000000099")
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.getEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.NOT_FOUND.code, exception.status.code)
+    }
+
+    @Test
+    fun `getEpisode with invalid uuid fails`() {
+        val request = GetEpisodeRequest.newBuilder()
+            .setId("not-a-uuid")
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.getEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.INVALID_ARGUMENT.code, exception.status.code)
+    }
+
+    @Test
+    fun `listEpisodes returns all episodes`() {
+        createTestEpisode("Episode 1")
+        createTestEpisode("Episode 2")
+
+        val request = ListEpisodesRequest.getDefaultInstance()
+        val response = client.listEpisodes(request).await().indefinitely()
+
+        assertEquals(2, response.episodesList.size)
+    }
+
+    @Test
+    fun `listEpisodes with page size returns limited results`() {
+        createTestEpisode("Episode 1")
+        createTestEpisode("Episode 2")
+        createTestEpisode("Episode 3")
+
+        val request = ListEpisodesRequest.newBuilder()
+            .setPageSize(2)
+            .build()
+
+        val response = client.listEpisodes(request).await().indefinitely()
+        assertEquals(2, response.episodesList.size)
+        assertTrue(response.nextPageToken.isNotEmpty())
+    }
+
+    @Test
+    fun `listEpisodes with status filter`() {
+        val episode = createTestEpisode("Filtered Episode")
+
+        val request = ListEpisodesRequest.newBuilder()
+            .setStatusFilter(ProtoEpisodeStatus.EPISODE_STATUS_PLANNING)
+            .build()
+
+        val response = client.listEpisodes(request).await().indefinitely()
+        assertTrue(response.episodesList.isNotEmpty())
+        assertTrue(response.episodesList.all { it.status == ProtoEpisodeStatus.EPISODE_STATUS_PLANNING })
+    }
+
+    @Test
+    fun `updateEpisode changes title`() {
+        val created = createTestEpisode("Original Title")
+
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId(created.id)
+            .setTitle("Updated Title")
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        val response = client.updateEpisode(request).await().indefinitely()
+        assertEquals("Updated Title", response.episode.title)
+    }
+
+    @Test
+    fun `updateEpisode valid status transition succeeds`() {
+        val created = createTestEpisode("Status Test")
+
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId(created.id)
+            .setStatus(ProtoEpisodeStatus.EPISODE_STATUS_RECORDING)
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        val response = client.updateEpisode(request).await().indefinitely()
+        assertEquals(ProtoEpisodeStatus.EPISODE_STATUS_RECORDING, response.episode.status)
+    }
+
+    @Test
+    fun `updateEpisode invalid status transition fails`() {
+        val created = createTestEpisode("Invalid Transition")
+
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId(created.id)
+            .setStatus(ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED)
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.updateEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.INVALID_ARGUMENT.code, exception.status.code)
+        assertTrue(requireNotNull(exception.status.description).contains("Invalid status transition"))
+    }
+
+    @Test
+    fun `updateEpisode with nonexistent id fails`() {
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId("00000000-0000-0000-0000-000000000099")
+            .setTitle("Ghost")
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.updateEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.NOT_FOUND.code, exception.status.code)
+    }
+
+    @Test
+    fun `deleteEpisode removes episode`() {
+        val created = createTestEpisode("Delete Me")
+
+        val deleteRequest = DeleteEpisodeRequest.newBuilder()
+            .setId(created.id)
+            .build()
+
+        client.deleteEpisode(deleteRequest).await().indefinitely()
+
+        val getRequest = GetEpisodeRequest.newBuilder()
+            .setId(created.id)
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.getEpisode(getRequest).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.NOT_FOUND.code, exception.status.code)
+    }
+
+    @Test
+    fun `deleteEpisode with nonexistent id fails`() {
+        val request = DeleteEpisodeRequest.newBuilder()
+            .setId("00000000-0000-0000-0000-000000000099")
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.deleteEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.NOT_FOUND.code, exception.status.code)
+    }
+
+    @Test
+    fun `full workflow transition path`() {
+        val created = createTestEpisode("Workflow Test")
+
+        val transitions = listOf(
+            ProtoEpisodeStatus.EPISODE_STATUS_GUEST_COORDINATION,
+            ProtoEpisodeStatus.EPISODE_STATUS_RECORDING,
+            ProtoEpisodeStatus.EPISODE_STATUS_EDITING,
+            ProtoEpisodeStatus.EPISODE_STATUS_REVIEW,
+            ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED,
+        )
+
+        var currentId = created.id
+        transitions.forEach { targetStatus ->
+            val updatedProto = ProtoEpisode.newBuilder()
+                .setId(currentId)
+                .setStatus(targetStatus)
+                .build()
+
+            val request = UpdateEpisodeRequest.newBuilder()
+                .setEpisode(updatedProto)
+                .build()
+
+            val response = client.updateEpisode(request).await().indefinitely()
+            assertEquals(targetStatus, response.episode.status)
+            currentId = response.episode.id
+        }
+    }
+
+    @Test
+    fun `published episode cannot transition`() {
+        val created = createTestEpisode("Published Lock")
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_RECORDING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_EDITING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_REVIEW)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED)
+
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId(created.id)
+            .setStatus(ProtoEpisodeStatus.EPISODE_STATUS_EDITING)
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        val exception = assertThrows<StatusRuntimeException> {
+            client.updateEpisode(request).await().indefinitely()
+        }
+        assertEquals(io.grpc.Status.INVALID_ARGUMENT.code, exception.status.code)
+    }
+
+    @Test
+    fun `review to editing and back to review succeeds`() {
+        val created = createTestEpisode("Review Cycle")
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_RECORDING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_EDITING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_REVIEW)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_EDITING)
+
+        val response = transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_REVIEW)
+        assertEquals(ProtoEpisodeStatus.EPISODE_STATUS_REVIEW, response.episode.status)
+    }
+
+    @Test
+    fun `published episode has published_at timestamp set`() {
+        val created = createTestEpisode("Publish Time")
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_RECORDING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_EDITING)
+        transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_REVIEW)
+        val response = transitionTo(created.id, ProtoEpisodeStatus.EPISODE_STATUS_PUBLISHED)
+
+        assertTrue(response.episode.hasPublishedAt())
+        assertTrue(response.episode.publishedAt.seconds > 0)
+    }
+
+    private fun createTestEpisode(title: String): ProtoEpisode {
+        val request = CreateEpisodeRequest.newBuilder()
+            .setTitle(title)
+            .build()
+        return client.createEpisode(request).await().indefinitely().episode
+    }
+
+    @Transactional
+    fun createTestGuest(): Guest {
+        val guest = Guest().apply {
+            name = "Test Guest"
+            email = "guest@example.com"
+        }
+        guestRepository.persistAndFlush(guest)
+        return guest
+    }
+
+    private fun transitionTo(
+        episodeId: String,
+        status: ProtoEpisodeStatus,
+    ): com.akaitigo.podflow.grpc.UpdateEpisodeResponse {
+        val updatedProto = ProtoEpisode.newBuilder()
+            .setId(episodeId)
+            .setStatus(status)
+            .build()
+
+        val request = UpdateEpisodeRequest.newBuilder()
+            .setEpisode(updatedProto)
+            .build()
+
+        return client.updateEpisode(request).await().indefinitely()
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -6,3 +6,6 @@ quarkus.datasource.password=
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.flyway.migrate-at-start=false
+
+# gRPC test client
+quarkus.grpc.clients.episode-service.host=localhost

--- a/plan-issue3.md
+++ b/plan-issue3.md
@@ -1,0 +1,59 @@
+# Plan: Issue #3 — Episode CRUD gRPC サービス実装
+
+## 前提
+- Issue #2 で proto 定義、エンティティ、リポジトリ、Flyway マイグレーションは作成済み
+- Quarkus gRPC (Mutiny API) で実装
+- テストは H2 インメモリDB + @QuarkusTest
+
+## 実装ステップ
+
+### Step 1: proto ファイルを Quarkus が認識する場所に配置
+- `backend/src/main/proto/` にシンボリックリンクまたは直接ファイルを配置
+- Quarkus は `src/main/proto` 内の `.proto` を自動検出してスタブ生成
+- `build.gradle.kts` に proto 依存（`com.google.protobuf:protobuf-java`）が必要な場合追加
+
+### Step 2: ステータス遷移ロジック追加
+- ファイル: `EpisodeStatus.kt`
+- `allowedTransitions` マップと `canTransitionTo()` メソッドを追加
+- 純粋ロジックなので Quarkus 依存なし
+
+### Step 3: エンティティ ↔ proto 変換ヘルパー
+- ファイル: `service/EpisodeMapper.kt`（新規）
+- `Episode` エンティティ → proto `Episode` メッセージ変換
+- proto `EpisodeStatus` ↔ Kotlin `EpisodeStatus` 変換
+- `Instant` ↔ `Timestamp` 変換
+
+### Step 4: gRPC サービス実装
+- ファイル: `service/EpisodeGrpcService.kt`（新規）
+- `@GrpcService` + Mutiny API ベース
+- 5 メソッド: CreateEpisode, GetEpisode, ListEpisodes, UpdateEpisode, DeleteEpisode
+- `@Transactional` でトランザクション管理
+- gRPC `StatusException` でエラーハンドリング
+
+### Step 5: テスト実装
+- `EpisodeStatusTest.kt` — ステータス遷移ユニットテスト
+- `EpisodeGrpcServiceTest.kt` — gRPC CRUD 統合テスト（@QuarkusTest）
+
+### Step 6: ビルド検証
+- `./gradlew build` 全パス（lint + compile + test）
+
+## ファイル構成（新規・変更）
+
+```
+backend/
+  src/main/proto/
+    podflow/v1/episode.proto          (コピー)
+    podflow/v1/episode_service.proto  (コピー)
+  src/main/kotlin/com/akaitigo/podflow/
+    model/EpisodeStatus.kt            (変更: 遷移ロジック追加)
+    service/EpisodeMapper.kt          (新規)
+    service/EpisodeGrpcService.kt     (新規)
+  src/test/kotlin/com/akaitigo/podflow/
+    model/EpisodeStatusTest.kt        (新規)
+    service/EpisodeGrpcServiceTest.kt (新規)
+```
+
+## リスク
+- Quarkus の gRPC コード生成が proto の `java_package` 設定を正しく反映するか確認が必要
+- H2 の UUID 型対応（H2 は UUID をネイティブサポートするので問題ないはず）
+- Mutiny の `Uni` 内での `@Transactional` 動作（Quarkus が自動対応）

--- a/research-issue3.md
+++ b/research-issue3.md
@@ -1,0 +1,116 @@
+# Research: Issue #3 — Episode CRUD gRPC サービス実装
+
+## 1. Quarkus gRPC サービス実装パターン
+
+### proto ファイル配置
+- Quarkus の `quarkus-grpc` 拡張は `src/main/proto` に配置された `.proto` ファイルを自動検出
+- ビルド時に Java/gRPC スタブを自動生成（`mvn compile` / `gradlew build`）
+- 外部の `proto/` ディレクトリにある定義を使うには、`src/main/proto` にシンボリックリンクまたはコピーする必要がある
+
+### Quarkus gRPC の実装方式（2 パターン）
+
+**Mutiny API（推奨）**
+```kotlin
+@GrpcService
+class EpisodeGrpcService : MutinyEpisodeServiceGrpc.EpisodeServiceImplBase() {
+    override fun createEpisode(request: CreateEpisodeRequest): Uni<CreateEpisodeResponse> {
+        // Uni を返す非同期パターン
+    }
+}
+```
+
+**StreamObserver API（従来型）**
+```kotlin
+@GrpcService
+class EpisodeGrpcService : EpisodeServiceGrpc.EpisodeServiceImplBase() {
+    override fun createEpisode(request: CreateEpisodeRequest, observer: StreamObserver<CreateEpisodeResponse>) {
+        // StreamObserver パターン
+    }
+}
+```
+
+### 結論
+- Mutiny API を採用（Quarkus 推奨、Kotlin coroutines とも相性が良い）
+- `@GrpcService` アノテーションで CDI Bean として自動登録
+
+## 2. ステータス遷移ルール
+
+### 遷移図
+```
+PLANNING ──→ GUEST_COORDINATION ──→ RECORDING ──→ EDITING ──→ REVIEW ──→ PUBLISHED
+    │                                                           │
+    └──────────→ RECORDING（ソロ収録）                          └──→ EDITING（修正依頼）
+```
+
+### 許可される遷移
+| 現在のステータス       | 遷移先                                     |
+|-----------------------|-------------------------------------------|
+| PLANNING              | GUEST_COORDINATION, RECORDING             |
+| GUEST_COORDINATION    | RECORDING                                 |
+| RECORDING             | EDITING                                   |
+| EDITING               | REVIEW                                    |
+| REVIEW                | EDITING（修正依頼）, PUBLISHED             |
+| PUBLISHED             | （遷移不可 — 最終ステータス）                |
+
+### バリデーション実装
+- `EpisodeStatus` に `canTransitionTo(target: EpisodeStatus): Boolean` メソッドを追加
+- 不正遷移時は `io.grpc.StatusException(Status.INVALID_ARGUMENT)` をスロー
+
+## 3. gRPC エラーハンドリング
+
+### StatusException の使用
+```kotlin
+throw StatusException(Status.NOT_FOUND.withDescription("Episode not found: $id"))
+throw StatusException(Status.INVALID_ARGUMENT.withDescription("Invalid status transition"))
+throw StatusException(Status.ALREADY_EXISTS.withDescription("Episode already exists"))
+```
+
+### エラーコードマッピング
+| ケース                | gRPC Status          |
+|----------------------|---------------------|
+| エピソード未発見       | NOT_FOUND           |
+| 不正な入力            | INVALID_ARGUMENT    |
+| 不正なステータス遷移   | INVALID_ARGUMENT    |
+| title が空            | INVALID_ARGUMENT    |
+| 内部エラー            | INTERNAL            |
+
+## 4. テスト戦略
+
+### H2 インメモリDB（既存設定を活用）
+- `src/test/resources/application.properties` で H2 設定済み
+- `quarkus.hibernate-orm.database.generation=drop-and-create` でテストごとにスキーマ再作成
+- Flyway は無効（`quarkus.flyway.migrate-at-start=false`）
+
+### テスト分類
+
+**ユニットテスト: ステータス遷移ロジック**
+- 純粋な Kotlin テスト（Quarkus 不要）
+- EpisodeStatus の遷移マトリクスを検証
+
+**統合テスト: gRPC CRUD**
+- `@QuarkusTest` + `@GrpcClient` でサービスを呼び出し
+- H2 インメモリDB で DB 操作を検証
+
+### Quarkus gRPC テストパターン
+```kotlin
+@QuarkusTest
+class EpisodeGrpcServiceTest {
+    @GrpcClient
+    lateinit var client: EpisodeService  // Mutiny 生成クライアント
+
+    @Test
+    fun `create episode`() {
+        val response = client.createEpisode(request).await().indefinitely()
+        // アサーション
+    }
+}
+```
+
+## 5. proto-to-Kotlin データ変換
+
+### エンティティ ↔ proto メッセージ変換
+- `Episode`（JPA エンティティ） ↔ `Episode`（proto メッセージ）の変換ヘルパーが必要
+- Mapper クラスで双方向変換を提供
+- `Instant` ↔ `google.protobuf.Timestamp` 変換
+- `UUID` ↔ `String` 変換
+- `EpisodeStatus`（Kotlin enum） ↔ `EpisodeStatus`（proto enum）変換


### PR DESCRIPTION
## Summary
- EpisodeGrpcService implementing 5 CRUD operations (Create, Get, List, Update, Delete) with Quarkus Mutiny API + `@GrpcService`
- Status transition validation enforcing the workflow: PLANNING -> GUEST_COORDINATION -> RECORDING -> EDITING -> REVIEW -> PUBLISHED
- EpisodeMapper for bidirectional entity <-> proto message conversion
- gRPC error handling with appropriate Status codes (NOT_FOUND, INVALID_ARGUMENT)

## Changes
- **`backend/src/main/kotlin/.../service/EpisodeGrpcService.kt`** (new): gRPC service with `@Blocking` + `@Transactional` for Hibernate/Panache operations
- **`backend/src/main/kotlin/.../service/EpisodeMapper.kt`** (new): Entity <-> proto conversion (EpisodeStatus, Timestamp, UUID)
- **`backend/src/main/kotlin/.../model/EpisodeStatus.kt`** (modified): Added `canTransitionTo()` and `allowedTransitions()` methods
- **`backend/src/main/proto/`** (new): Proto files copied for Quarkus auto code generation
- **`backend/src/test/.../model/EpisodeStatusTest.kt`** (new): 24 parameterized tests for status transitions
- **`backend/src/test/.../service/EpisodeGrpcServiceTest.kt`** (new): 20 integration tests (@QuarkusTest + H2)
- **`backend/src/test/resources/application.properties`** (modified): Added gRPC test client config

## Test plan
- [x] `./gradlew build` passes (detekt + compile + 45 tests)
- [x] `buf lint proto/` passes
- [x] Status transition unit tests: valid/invalid transitions, self-transition rejection
- [x] gRPC integration tests: CRUD operations, error handling, full workflow path
- [x] Published episode timestamp set on transition to PUBLISHED

Closes #3