### PR TITLE
fix: JWT displayNameクレームにusernameが入るバグを修正

### DIFF
--- a/backend/src/main/kotlin/com/akaitigo/podflow/auth/AuthResource.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/auth/AuthResource.kt
@@ -146,6 +146,7 @@ class AuthResource @Inject constructor(
         jwtTokenService.generateToken(
             userId = requireNotNull(user.id).toString(),
             username = user.username,
+            displayName = user.displayName,
             role = user.role,
         )
 

--- a/backend/src/main/kotlin/com/akaitigo/podflow/auth/JwtTokenService.kt
+++ b/backend/src/main/kotlin/com/akaitigo/podflow/auth/JwtTokenService.kt
@@ -16,12 +16,12 @@ class JwtTokenService(
 ) {
 
     /** Generate a signed JWT for the given user. */
-    fun generateToken(userId: String, username: String, role: String): String =
+    fun generateToken(userId: String, username: String, displayName: String, role: String): String =
         Jwt.issuer(issuer)
             .subject(userId)
             .upn(username)
             .groups(setOf(role))
-            .claim("displayName", username)
+            .claim("displayName", displayName)
             .expiresIn(Duration.ofMinutes(expirationMinutes))
             .sign()
 }

--- a/backend/src/test/kotlin/com/akaitigo/podflow/auth/TestJwtHelper.kt
+++ b/backend/src/test/kotlin/com/akaitigo/podflow/auth/TestJwtHelper.kt
@@ -9,19 +9,21 @@ object TestJwtHelper {
     private const val TEST_ISSUER = "https://podflow.akaitigo.com"
     private const val TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
     private const val TEST_USERNAME = "testuser"
+    private const val TEST_DISPLAY_NAME = "Test User"
     private const val TEST_ROLE = "USER"
 
     /** Generate a valid test JWT token. */
     fun generateTestToken(
         userId: String = TEST_USER_ID,
         username: String = TEST_USERNAME,
+        displayName: String = TEST_DISPLAY_NAME,
         role: String = TEST_ROLE,
     ): String =
         Jwt.issuer(TEST_ISSUER)
             .subject(userId)
             .upn(username)
             .groups(setOf(role))
-            .claim("displayName", username)
+            .claim("displayName", displayName)
             .expiresIn(Duration.ofHours(1))
             .sign()
 


### PR DESCRIPTION
## Summary
- `JwtTokenService.generateToken()` の `displayName` クレームに `username` が設定されていたバグを修正
- `generateToken()` に `displayName` パラメータを追加し、`AuthResource.generateTokenForUser()` から `user.displayName` を渡すように変更
- テストヘルパー `TestJwtHelper` も同様に `displayName` パラメータを追加

## Test plan
- [x] `./gradlew build` でビルド+全103テスト通過確認済み
- [x] 既存テストへの影響なし（TestJwtHelperはデフォルト引数で後方互換）